### PR TITLE
feat: remove transfers to self

### DIFF
--- a/subgraphs/enzyme-core/mappings/v4/VaultLib.ts
+++ b/subgraphs/enzyme-core/mappings/v4/VaultLib.ts
@@ -77,6 +77,12 @@ export function handleTransfer(event: Transfer): void {
     return;
   }
 
+  // do not track transfers to self (which can occur with entrance/exit direct fees,
+  // if the depositor is also the fee recipient)
+  if (event.params.from.equals(event.params.to)) {
+    return;
+  }
+
   let vault = useVault(event.address.toHex());
   let shares = toBigDecimal(event.params.value);
 


### PR DESCRIPTION
Transfers with `to` and `from` address identical occur for exit/entrance direct fee when the depositor and fee recipient are identical.

This is not a 'real' share transfer, and should be excluded from our activity feed (similar to burn/mint).