### PR TITLE
fix: remove fee amount from liquity borrow position change

### DIFF
--- a/subgraphs/enzyme-core/entities/LiquityDebtPosition.ts
+++ b/subgraphs/enzyme-core/entities/LiquityDebtPosition.ts
@@ -44,7 +44,6 @@ export function createLiquityDebtPositionChange(
   incomingAssetAmounts: AssetAmount[],
   outgoingAssetAmount: AssetAmount | null,
   lusdGasCompensationAssetAmount: AssetAmount | null,
-  feeAssetAmount: AssetAmount | null,
   vault: Vault,
   event: ethereum.Event,
 ): LiquityDebtPositionChange {
@@ -55,7 +54,6 @@ export function createLiquityDebtPositionChange(
   change.outgoingAssetAmount = outgoingAssetAmount != null ? outgoingAssetAmount.id : null;
   change.lusdGasCompensationAssetAmount =
     lusdGasCompensationAssetAmount != null ? lusdGasCompensationAssetAmount.id : null;
-  change.feeAssetAmount = feeAssetAmount != null ? feeAssetAmount.id : null;
   change.vault = vault.id;
   change.timestamp = event.block.timestamp.toI32();
   change.activityCounter = getActivityCounter();

--- a/subgraphs/enzyme-core/mappings/v4/ExternalPositionManager.ts
+++ b/subgraphs/enzyme-core/mappings/v4/ExternalPositionManager.ts
@@ -654,20 +654,13 @@ export function handleCallOnExternalPositionExecutedForFund(event: CallOnExterna
 
       let incomingAsset = createAssetAmount(lusdAsset, lusdAmount, denominationAsset, 'ldp-incoming', event);
 
-      let ldp = useLiquityDebtPosition(event.params.externalPosition.toHex());
-
-      let borrowedBalance = ldp.borrowedBalance;
-      let borrowedAmount = getLiquityDebtPositionBorrowedAmount(event.params.externalPosition.toHex());
-      let feeAmount = borrowedAmount.minus(lusdAmount).minus(borrowedBalance);
-      let feeAssetAmount = createAssetAmount(lusdAsset, feeAmount, denominationAsset, 'ldp-fee-asset-amount', event);
-
       createLiquityDebtPositionChange(
         event.params.externalPosition,
         'Borrow',
         [incomingAsset],
         null,
         null,
-        feeAssetAmount,
+        null,
         vault,
         event,
       );

--- a/subgraphs/enzyme-core/mappings/v4/ExternalPositionManager.ts
+++ b/subgraphs/enzyme-core/mappings/v4/ExternalPositionManager.ts
@@ -571,18 +571,12 @@ export function handleCallOnExternalPositionExecutedForFund(event: CallOnExterna
         event,
       );
 
-      let borrowedAmount = getLiquityDebtPositionBorrowedAmount(event.params.externalPosition.toHex());
-
-      let feeAmount = borrowedAmount.minus(lusdAmount).minus(lusdGasCompensationAmountBD);
-      let feeAssetAmount = createAssetAmount(lusdAsset, feeAmount, denominationAsset, 'ldp-fee', event);
-
       createLiquityDebtPositionChange(
         event.params.externalPosition,
         'OpenTrove',
         [incomingAsset],
         outgoingAsset,
         lusdGasCompensationAssetAmount,
-        feeAssetAmount,
         vault,
         event,
       );
@@ -608,7 +602,6 @@ export function handleCallOnExternalPositionExecutedForFund(event: CallOnExterna
         [],
         outgoingAsset,
         null,
-        null,
         vault,
         event,
       );
@@ -632,7 +625,6 @@ export function handleCallOnExternalPositionExecutedForFund(event: CallOnExterna
         event.params.externalPosition,
         'RemoveCollateral',
         [incomingAsset],
-        null,
         null,
         null,
         vault,
@@ -660,7 +652,6 @@ export function handleCallOnExternalPositionExecutedForFund(event: CallOnExterna
         [incomingAsset],
         null,
         null,
-        null,
         vault,
         event,
       );
@@ -685,7 +676,6 @@ export function handleCallOnExternalPositionExecutedForFund(event: CallOnExterna
         'Repay',
         [],
         outgoingAsset,
-        null,
         null,
         vault,
         event,
@@ -726,7 +716,6 @@ export function handleCallOnExternalPositionExecutedForFund(event: CallOnExterna
         'CloseTrove',
         [collateralAssetAmount, lusdGasCompensationAssetAmount],
         borrowedAssetAmount,
-        null,
         null,
         vault,
         event,

--- a/subgraphs/enzyme-core/schema.graphql
+++ b/subgraphs/enzyme-core/schema.graphql
@@ -1309,7 +1309,6 @@ type LiquityDebtPositionChange implements Activity & VaultActivity & ExternalPos
   liquityDebtPositionChangeType: LiquityDebtPositionChangeType!
   incomingAssetAmounts: [AssetAmount!]!
   lusdGasCompensationAssetAmount: AssetAmount
-  feeAssetAmount: AssetAmount
   outgoingAssetAmount: AssetAmount
   activityCounter: Int!
   activityCategories: [ActivityCategory!]!


### PR DESCRIPTION
Remove the fee asset amount from liquity debt position change due to an issue with how Liquity nets the fee with collateral on a borrow transaction.