### PR TITLE
fix: shares wrapper balance since

### DIFF
--- a/subgraphs/enzyme-core/entities/GatedRedemptionQueueSharesWrapper.ts
+++ b/subgraphs/enzyme-core/entities/GatedRedemptionQueueSharesWrapper.ts
@@ -1,4 +1,4 @@
-import { Address } from '@graphprotocol/graph-ts';
+import { Address, ethereum } from '@graphprotocol/graph-ts';
 import {
   Account,
   Asset,
@@ -215,6 +215,7 @@ export function gatedRedemptionQueueSharesWrapperDepositorBalanceId(
 export function ensureGatedRedemptionQueueSharesWrapperDepositorBalance(
   wrapper: GatedRedemptionQueueSharesWrapper,
   account: Account,
+  event: ethereum.Event,
 ): GatedRedemptionQueueSharesWrapperDepositorBalance {
   let id = gatedRedemptionQueueSharesWrapperDepositorBalanceId(wrapper, account);
   let balance = GatedRedemptionQueueSharesWrapperDepositorBalance.load(id);
@@ -227,6 +228,7 @@ export function ensureGatedRedemptionQueueSharesWrapperDepositorBalance(
   balance.wrapper = wrapper.id;
   balance.account = account.id;
   balance.shares = ZERO_BD;
+  balance.since = event.block.timestamp.toI32();
   balance.save();
 
   return balance;

--- a/subgraphs/enzyme-core/mappings/GatedRedemptionQueueSharesWrapperLib.ts
+++ b/subgraphs/enzyme-core/mappings/GatedRedemptionQueueSharesWrapperLib.ts
@@ -247,13 +247,13 @@ export function handleTransfer(event: Transfer): void {
   }
 
   if (event.params.from.notEqual(ZERO_ADDRESS)) {
-    let senderBalance = ensureGatedRedemptionQueueSharesWrapperDepositorBalance(wrapper, sender);
+    let senderBalance = ensureGatedRedemptionQueueSharesWrapperDepositorBalance(wrapper, sender, event);
     senderBalance.shares = senderBalance.shares.minus(sharesAmount);
     senderBalance.save();
   }
 
   if (event.params.to.notEqual(ZERO_ADDRESS)) {
-    let recipientBalance = ensureGatedRedemptionQueueSharesWrapperDepositorBalance(wrapper, recipient);
+    let recipientBalance = ensureGatedRedemptionQueueSharesWrapperDepositorBalance(wrapper, recipient, event);
     recipientBalance.shares = recipientBalance.shares.plus(sharesAmount);
     recipientBalance.save();
   }

--- a/subgraphs/enzyme-core/schema.graphql
+++ b/subgraphs/enzyme-core/schema.graphql
@@ -2256,6 +2256,7 @@ type GatedRedemptionQueueSharesWrapperDepositorBalance @entity {
   wrapper: GatedRedemptionQueueSharesWrapper!
   account: Account!
   shares: BigDecimal!
+  since: Int!
 
   sharesChanges: [GatedRedemptionQueueSharesWrapperSharesChange!]! @derivedFrom(field: "depositorBalance")
 }


### PR DESCRIPTION
Shares wrapper balances currently do not have a `since` timestamp, which is needed in the depositor tab for vaults. This PR adds a the relevant timestamp.